### PR TITLE
Set paths to smart.sh script and .smart-runner.lock files relative to script directory

### DIFF
--- a/smart-runner.py
+++ b/smart-runner.py
@@ -21,6 +21,11 @@ from smart_runner import (
     TooSoonException,
 )
 from sys import exit
+from os import path
+
+
+SMART_SCRIPT_PATH = path.realpath(path.dirname(__file__)) + "/smart.sh"
+LOCK_FILE_PATH = path.realpath(path.dirname(__file__)) + "/.smart-runner.lock"
 
 
 def sendTestFailureEmail(config, logger, test, disk):
@@ -31,10 +36,10 @@ def sendTestFailureEmail(config, logger, test, disk):
     try:
         Email.send(
             message=Message(
-                subject="{} SMART test failed for disk {}".format(
-                    test.testType.value, disk.disk
+                subject="SMART test failed on {}".format(disk.disk),
+                body="A {} SMART test has failed on {}. Please see server logs located at {} for more details.".format(
+                    test.testType.value, disk.disk, config.log.file
                 ),
-                body="Please see server logs for more details",
                 fromEmail=config.email.from_email,
                 toEmail=config.email.to_email,
             ),
@@ -55,7 +60,7 @@ def sendTestFailureEmail(config, logger, test, disk):
 
 def main():
     try:
-        Lock()
+        Lock(LOCK_FILE_PATH)
         args = Args()
         config = Config(configFile=args.config)
         db = Database(dbFile=config.database.file)
@@ -76,6 +81,7 @@ def main():
         ]
         shortTest = Test(
             testType=TestType.SHORT,
+            smartScriptPath=SMART_SCRIPT_PATH,
             enabled=config.short.enabled,
             frequencyDays=config.short.frequency_days,
             offsetDays=config.short.offset_days,
@@ -84,6 +90,7 @@ def main():
         )
         longTest = Test(
             testType=TestType.LONG,
+            smartScriptPath=SMART_SCRIPT_PATH,
             enabled=config.long.enabled,
             frequencyDays=config.long.frequency_days,
             offsetDays=config.long.offset_days,

--- a/smart_runner/lock.py
+++ b/smart_runner/lock.py
@@ -1,11 +1,11 @@
 from atexit import register
-from os import getcwd, remove
-
-LOCK_FILE_PATH = getcwd() + "/.smart-runner.lock"
+from os import remove
 
 
 class Lock:
-    def __init__(self):
+    def __init__(self, file):
+        self.file = file
+
         if self.isLocked():
             raise RuntimeError("smart-runner is already running")
 
@@ -15,18 +15,18 @@ class Lock:
         register(self.removeLock)
 
     def createLock(self):
-        with open(LOCK_FILE_PATH, "w") as lockFile:
+        with open(self.file, "w") as lockFile:
             lockFile.write("")
 
     def removeLock(self):
         try:
-            remove(LOCK_FILE_PATH)
+            remove(self.file)
         except FileNotFoundError:
             pass  # If the file is already removed or doesn't exist, ignore the error
 
     def isLocked(self):
         try:
-            with open(LOCK_FILE_PATH, "r") as lockFile:
+            with open(self.file, "r") as lockFile:
                 return True
         except FileNotFoundError:
             return False

--- a/smart_runner/test.py
+++ b/smart_runner/test.py
@@ -1,9 +1,6 @@
 from .command import Command
 from enum import Enum
 from datetime import datetime, timedelta
-from os import getcwd
-
-SMART_RUNNER_PATH = getcwd() + "/smart.sh"
 
 
 class TestType(Enum):
@@ -35,6 +32,7 @@ class Test:
     def __init__(
         self,
         testType,
+        smartScriptPath,
         enabled=False,
         frequencyDays=1,
         offsetDays=0,
@@ -42,6 +40,7 @@ class Test:
         lastTestDate=None,
     ):
         self.testType = testType
+        self.smartScriptPath = smartScriptPath
         self.enabled = enabled
         self.frequencyDays = frequencyDays
         self.offsetDays = offsetDays
@@ -77,7 +76,7 @@ class Test:
         self.disks.append(disk)
 
         command = Command(
-            cmd=SMART_RUNNER_PATH + " " + self.testType.value + " " + disk.disk,
+            cmd=self.smartScriptPath + " " + self.testType.value + " " + disk.disk,
             stdout=onOutput,
             stderr=onError,
         )


### PR DESCRIPTION
### Description

Set paths to `smart.sh` script and `.smart-runner.lock` files relative to script directory instead of CWD.

Fix issue with running this script from a different working directory.