### PR TITLE
Add log.level config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The script is configured via a `smart-runner.conf` file. Here's an explanation o
 |            | `disks_per_run`  | Number of disks to test in parallel for long tests. Set to 0 for all.                                                              |
 |            | `offset_days`    | Time to wait (in days) before running a long test on a different disk.                                                             |
 | `log`      | `file`           | Path to the log file where execution details are recorded.                                                                         |
+|            | `level`          | Log level. Set to `debug` for more detailed logs.                                                                                  |
 | `email`    | `enabled`        | Set to `true` to enable email notifications for test failures.                                                                     |
 |            | `from_email`     | Sender email address for notifications.                                                                                            |
 |            | `to_email`       | Recipient email address for notifications.                                                                                         |

--- a/smart-runner.conf.example
+++ b/smart-runner.conf.example
@@ -6,6 +6,7 @@
 
 [database]
 file = /var/lib/smart-runner/smart-runner.json
+level = INFO
 
 ; short SMART test settings (these tests typically take a few minutes)
 [short]

--- a/smart_runner/__init__.py
+++ b/smart_runner/__init__.py
@@ -6,4 +6,5 @@ from .disk import *
 from .email import *
 from .lock import *
 from .logger import *
+from .smart import *
 from .test import *

--- a/smart_runner/config.py
+++ b/smart_runner/config.py
@@ -69,6 +69,7 @@ class Config:
                         "file": config.get(
                             "log", "file", fallback="/var/log/smart-runner.log"
                         ),
+                        "level": config.get("log", "level", fallback="INFO"),
                     }
                 ),
                 "email": ConfigDict(

--- a/smart_runner/disk.py
+++ b/smart_runner/disk.py
@@ -83,3 +83,13 @@ class Disk:
             return None
         except Exception as e:
             raise Exception("Failed to get last test date for disk: {}".format(e))
+
+    def updateLastTestDateForTest(self, test: Test):
+        try:
+            if test.testType == TestType.SHORT:
+                self.lastShortTestDate = datetime.now()
+
+            if test.testType == TestType.LONG:
+                self.lastLongTestDate = datetime.now()
+        except Exception as e:
+            raise Exception("Failed to update last test date for disk: {}".format(e))

--- a/smart_runner/logger.py
+++ b/smart_runner/logger.py
@@ -3,8 +3,9 @@ from sys import stdout
 
 
 class Logger:
-    def __init__(self, logFile):
+    def __init__(self, logFile, level):
         self.logFile = logFile
+        self.level = level.upper()
         self.__logger__ = getLogger()
         self.__setupLogger__()
 
@@ -18,7 +19,7 @@ class Logger:
             stdoutHandler = StreamHandler(stdout)
             stdoutHandler.setFormatter(formatter)
 
-            self.__logger__.setLevel(DEBUG)
+            self.__logger__.setLevel(self.level)
             self.__logger__.addHandler(fileHander)
             self.__logger__.addHandler(stdoutHandler)
         except Exception as e:

--- a/smart_runner/smart.py
+++ b/smart_runner/smart.py
@@ -1,0 +1,23 @@
+from .command import Command
+
+
+class TestFailedException(Exception):
+    pass
+
+
+class Smart:
+    def __init__(self, testType, disk, smartScriptPath):
+        self.testType = testType
+        self.disk = disk
+        self.smartScriptPath = smartScriptPath
+
+    def run(self, onOutput, onError):
+        command = Command(
+            cmd=self.smartScriptPath + " " + self.testType + " " + self.disk,
+            stdout=onOutput,
+            stderr=onError,
+        )
+        status = command.exec()
+
+        if status != 0:
+            raise TestFailedException()

--- a/smart_runner/test.py
+++ b/smart_runner/test.py
@@ -1,4 +1,3 @@
-from .command import Command
 from enum import Enum
 from datetime import datetime, timedelta
 
@@ -24,15 +23,10 @@ class TooSoonException(Exception):
     pass
 
 
-class TestFailedException(Exception):
-    pass
-
-
 class Test:
     def __init__(
         self,
         testType,
-        smartScriptPath,
         enabled=False,
         frequencyDays=1,
         offsetDays=0,
@@ -40,7 +34,6 @@ class Test:
         lastTestDate=None,
     ):
         self.testType = testType
-        self.smartScriptPath = smartScriptPath
         self.enabled = enabled
         self.frequencyDays = frequencyDays
         self.offsetDays = offsetDays
@@ -60,7 +53,7 @@ class Test:
 
         return (datetime.now() - self.lastTestDate).days
 
-    def runTestForDisk(self, disk, onOutput, onError, onFinished):
+    def enqueueForDisk(self, disk):
         if not self.enabled:
             raise NotEnabledException()
 
@@ -75,14 +68,8 @@ class Test:
 
         self.disks.append(disk)
 
-        command = Command(
-            cmd=self.smartScriptPath + " " + self.testType.value + " " + disk.disk,
-            stdout=onOutput,
-            stderr=onError,
+    def enqueuedDisks(self):
+        return sorted(
+            self.disks, key=lambda disk: disk.getLastTestDateForTest(self) or datetime.min
         )
-        status = command.exec()
 
-        onFinished()
-
-        if status != 0:
-            raise TestFailedException()


### PR DESCRIPTION
### Description

Few new features to support `log.level` config option:

- Add `log.level` config option
- Set some logs to be debug only
- Enqueue tests before running so there aren't extra `****...` logs